### PR TITLE
Azure: Support fallback to bind mount instead of a volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,24 @@ FROM ubuntu:20.04
 
 RUN mkdir -p /opt/datavirtuality
 COPY dvserver /opt/datavirtuality/dvserver
-COPY dvconfig.conf.props /opt/datavirtuality/dvserver/bin/
-COPY dvserver-container.sh /opt/datavirtuality/dvserver/bin/
 
-RUN mkdir /opt/datavirtuality/original_files && cp /opt/datavirtuality/dvserver/standalone/data/datavirtuality/license.lic /opt/datavirtuality/original_files/ && cp /opt/datavirtuality/dvserver/standalone/configuration/dvserver-standalone.xml /opt/datavirtuality/original_files/
+WORKDIR /opt/datavirtuality/dvserver
+
+COPY dvconfig.conf.props bin/
+COPY dvserver-container.sh bin/
+
+RUN mkdir /opt/datavirtuality/original_files && cp standalone/data/datavirtuality/license.lic /opt/datavirtuality/original_files/ && cp standalone/configuration/dvserver-standalone.xml /opt/datavirtuality/original_files/
 
 RUN mkdir /opt/datavirtuality/persistent_data /opt/datavirtuality/persistent_data/log
-RUN mv /opt/datavirtuality/dvserver/standalone/data/datavirtuality/license.lic /opt/datavirtuality/persistent_data/
-RUN mv /opt/datavirtuality/dvserver/standalone/configuration/dvserver-standalone.xml /opt/datavirtuality/persistent_data/
+RUN mv standalone/data/datavirtuality/license.lic /opt/datavirtuality/persistent_data/
+RUN mv standalone/configuration/dvserver-standalone.xml /opt/datavirtuality/persistent_data/
 
-RUN ln -s /opt/datavirtuality/persistent_data/license.lic /opt/datavirtuality/dvserver/standalone/data/datavirtuality/license.lic
-RUN ln -s /opt/datavirtuality/persistent_data/log /opt/datavirtuality/dvserver/standalone/log
-RUN ln -s /opt/datavirtuality/persistent_data/dvserver-standalone.xml /opt/datavirtuality/dvserver/standalone/configuration/dvserver-standalone.xml
+RUN ln -s /opt/datavirtuality/persistent_data/license.lic standalone/data/datavirtuality/license.lic
+RUN ln -s /opt/datavirtuality/persistent_data/log standalone/log
+RUN ln -s /opt/datavirtuality/persistent_data/dvserver-standalone.xml standalone/configuration/dvserver-standalone.xml
 
 VOLUME /opt/datavirtuality/persistent_data
 
 EXPOSE 8080/tcp 31000/tcp 31001/tcp 35432/tcp 35433/tcp
 
-CMD ["/opt/datavirtuality/dvserver/bin/dvserver-container.sh"]
+CMD ["bin/dvserver-container.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM ubuntu:20.04
 RUN mkdir -p /opt/datavirtuality
 COPY dvserver /opt/datavirtuality/dvserver
 COPY dvconfig.conf.props /opt/datavirtuality/dvserver/bin/
+COPY dvserver-container.sh /opt/datavirtuality/dvserver/bin/
+
+RUN mkdir /opt/datavirtuality/original_files && cp /opt/datavirtuality/dvserver/standalone/data/datavirtuality/license.lic /opt/datavirtuality/original_files/ && cp /opt/datavirtuality/dvserver/standalone/configuration/dvserver-standalone.xml /opt/datavirtuality/original_files/
 
 RUN mkdir /opt/datavirtuality/persistent_data /opt/datavirtuality/persistent_data/log
 RUN mv /opt/datavirtuality/dvserver/standalone/data/datavirtuality/license.lic /opt/datavirtuality/persistent_data/
@@ -16,4 +19,4 @@ VOLUME /opt/datavirtuality/persistent_data
 
 EXPOSE 8080/tcp 31000/tcp 31001/tcp 35432/tcp 35433/tcp
 
-CMD ["/opt/datavirtuality/dvserver/bin/dvserver.sh"]
+CMD ["/opt/datavirtuality/dvserver/bin/dvserver-container.sh"]

--- a/README.md
+++ b/README.md
@@ -24,12 +24,19 @@ $ ./dvserver-run.sh dvserver 2.3.10
 ```
 
 ### Where to store data
-By default, all data created during the runtime of the container remains within the container (except for the configuration database). This includes certain configuration files, the license and log files. To store these files permanently outside of the container, you can pass a volume as `-v $volume_name:/opt/datavirtuality/persistent_data`.
+By default, all data created during the runtime of the container remains within the container (except for the configuration database). This includes certain configuration files, the license and log files. To persist the data, you can either use a volume or bind mount. Volumes are recommended by Docker as the preferred way. 
+
+#### Using a volume
+Pass a volume as `-v $volume_name:/opt/datavirtuality/persistent_data`.
+
 The `dvserver-run.sh` script has this mechanism already built-in and you can pass the name of the volume to be used as a second parameter. The volume will be created automatically if it doesn't exist yet:
 
 ```console
 $ ./dvserver-run.sh dvserver 2.3.10 dv_data
 ```
+
+#### Using a bind mount
+If you need to use a bind mount, you can pass the option as `--mount type=bind,source=/tmp/source_directory,target=/opt/datavirtuality/persistent_data`. Replace `/tmp/source_directory` with an existing path on the host.
 
 ### docker-compose
 You can also use `docker compose` to manage the Data Virtuality Server container and the PostgreSQL configuration database container. See [dvserver-compose.yml](dvserver-compose.yml) for an example configuration that can be started with `docker-compose -f dvserver-compose.yml up`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ ./dvserver-run.sh dvserver 2.3.10
 
 ### Persistent data
 By default, all data created during the runtime of the container remains within the container (except for the configuration database). To persist the data, you can either use a volume or bind mount. Volumes are recommended by Docker as the preferred way. The following files/folders are stored inside the volume:
-* `log`: Contains all application log files
+* `log`: Directory containing all application log files
 * `license.lic`: The Data Virtuality license file
 * `dvserver-standalone.xml`: A central configuration file that usually does not need to be edited by the user directly
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ ./dvserver-run.sh dvserver 2.3.10
 By default, all data created during the runtime of the container remains within the container (except for the configuration database). This includes certain configuration files, the license and log files. To persist the data, you can either use a volume or bind mount. Volumes are recommended by Docker as the preferred way. 
 
 #### Using a volume
-Pass a volume as `-v $volume_name:/opt/datavirtuality/persistent_data`.
+Pass a volume as `--volume $volume_name:/opt/datavirtuality/persistent_data`.
 
 The `dvserver-run.sh` script has this mechanism already built-in and you can pass the name of the volume to be used as a second parameter. The volume will be created automatically if it doesn't exist yet:
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ Starting a container is simple, a bash script is included in the repository:
 $ ./dvserver-run.sh dvserver 2.3.10
 ```
 
-### Where to store data
-By default, all data created during the runtime of the container remains within the container (except for the configuration database). This includes certain configuration files, the license and log files. To persist the data, you can either use a volume or bind mount. Volumes are recommended by Docker as the preferred way. 
+### Persistent data
+By default, all data created during the runtime of the container remains within the container (except for the configuration database). To persist the data, you can either use a volume or bind mount. Volumes are recommended by Docker as the preferred way. The following files/folders are stored inside the volume:
+* `log`: Contains all application log files
+* `license.lic`: The Data Virtuality license file
+* `dvserver-standalone.xml`: A central configuration file that usually does not need to be edited by the user directly
 
 #### Using a volume
 Pass a volume as `--volume $volume_name:/opt/datavirtuality/persistent_data`.

--- a/dvserver-container.sh
+++ b/dvserver-container.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# if a bind mount is used instead of a volume, existing files will be missing. Fix it by copying them again.
+if [[ ! -f "/opt/datavirtuality/persistent_data/dvserver-standalone.xml" ]]; then
+    echo "bind mount detected, restoring files..."
+
+    mkdir -p /opt/datavirtuality/persistent_data/log
+    cp /opt/datavirtuality/original_files/license.lic /opt/datavirtuality/persistent_data/license.lic
+    cp /opt/datavirtuality/original_files/dvserver-standalone.xml /opt/datavirtuality/persistent_data/dvserver-standalone.xml
+fi
+
+/opt/datavirtuality/dvserver/bin/dvserver.sh


### PR DESCRIPTION
When using volumes, pre-existing files at the mount point will be added to the volumes. For bind mounts, this is not the case and we need a workaround to copy the files.